### PR TITLE
ハッシュタグ付きでツイートできるようにする

### DIFF
--- a/src/js/preview/preview.js
+++ b/src/js/preview/preview.js
@@ -54,6 +54,9 @@ function csv_array(data) {
   // Site URL (トレイリングスラッシュありに統一してる)
   const siteUrl = `${location.protocol}//${location.hostname}/`;
 
+  // Hashtag
+  const valHashtag = array.filter((value) => value.option === 'Hashtag')[0].value1;
+
   // Favicon
   try {
     const optFavicon = array.filter((value) => value.option === 'Site Icon (favicon)');
@@ -328,7 +331,6 @@ function csv_array(data) {
     const domShareFacebook = document.querySelector('.js-share-fb');
     let twitterLink = 'https://twitter.com/share?text=' + encodedSiteTitle + '&url=' + siteUrl;
     // ハッシュタグが設定されていればシェアURLに含める
-    const valHashtag = array.filter((value) => value.option === 'Hashtag')[0].value1;
     if (valHashtag != '') {
       twitterLink += '&hashtags=' + valHashtag;
     }
@@ -484,6 +486,21 @@ function csv_array(data) {
     domEventDate.textContent = valEventDate;
   } catch(error) {
     console.error('Error: Overview date');
+  }
+
+  // Hashtag
+  try {
+    const domEventHashtag = document.querySelector('.js-event-hashtag');
+    const domEventHashtagLink = document.querySelector('.js-event-hashtag-link');
+    if (valHashtag != '') {
+      domEventHashtagLink.textContent = '#' + valHashtag;
+      const eventHashtagLink = 'https://twitter.com/hashtag/' + valHashtag + '?src=hash';
+      domEventHashtagLink.setAttribute('href', eventHashtagLink);
+    } else {
+      domEventHashtag.remove();
+    }
+  } catch(error) {
+    console.error('Error: Overview hashtag');
   }
 
   // Venue

--- a/src/js/preview/preview.js
+++ b/src/js/preview/preview.js
@@ -326,14 +326,19 @@ function csv_array(data) {
   try {
     const domShareTwitter = document.querySelector('.js-share-tw');
     const domShareFacebook = document.querySelector('.js-share-fb');
-    const twitterLink = 'https://twitter.com/share?text=' + encodedSiteTitle + '&url=' + siteUrl;
+    let twitterLink = 'https://twitter.com/share?text=' + encodedSiteTitle + '&url=' + siteUrl;
+    // ハッシュタグが設定されていればシェアURLに含める
+    const valHashtag = array.filter((value) => value.option === 'Hashtag')[0].value1;
+    if (valHashtag != '') {
+      twitterLink += '&hashtags=' + valHashtag;
+    }
     domShareTwitter.setAttribute('href', twitterLink);
     const facebookLink = 'http://www.facebook.com/sharer.php?u=' + siteUrl;
     domShareFacebook.setAttribute('href', facebookLink);
+
   } catch(error) {
     console.error('Error: Share buttons');
   }
-
 
   // googleカレンダーに追加
   try {

--- a/src/scss/components/_overview.scss
+++ b/src/scss/components/_overview.scss
@@ -1,5 +1,11 @@
 .overview {
     margin: 0;
+    a {
+        color: var(--color-text);
+        &:hover {
+            color: var(--color-text-highlight);
+        }
+    }
 }
 .overview-label {
     color: var(--color-text-highlight);

--- a/src/scss/globals/_variable.scss
+++ b/src/scss/globals/_variable.scss
@@ -62,7 +62,7 @@
     --color-gray-400: #444444;
     --color-gray-800: #888888;
     --color-gray-900: #dddddd;
-    --color-primary: var(--color-red);
+    --color-primary: var(--color-red); // configシートで変えられる
     --color-service: #6107aa;
     --color-white-transparent: rgba(255,255,255,.16);  // 背景の上に薄い色を重ねたいとき
     --color-black-transparent: rgba(0,0,0,.16);  // 背景の上に薄い色を重ねたいとき

--- a/src/templates/pages/preview.ejs
+++ b/src/templates/pages/preview.ejs
@@ -217,6 +217,10 @@ pageId = "preview";
             <dd class="overview-content js-event-title">Event Title</dd>
             <dt class="overview-label">Date</dt>
             <dd class="overview-content js-event-date">2000/01/01 00:00</dd>
+            <dt class="overview-label">Hashtag</dt>
+            <dd class="overview-content js-event-hashtag">
+              <a href="https://twitter.com/search?q=" class="js-event-hashtag-link">#hashtag</a>
+            </dd>
             <dt class="overview-label js-event-venue-label">Venue Label</dt>
             <dd class="overview-content js-event-venue-content">Venue Content</dd>
             <dd class="overview-content js-event-venue-address">Address</dd>


### PR DESCRIPTION
- configシートでハッシュタグを設定できる
- 設定した場合、
  - ツイートボタンでのツイートがハッシュタグ付きになる
  - Overview欄にハッシュタグ表記と、Twitter検索結果へのリンク

<img width="538" alt="スクリーンショット 2021-11-21 11 04 05" src="https://user-images.githubusercontent.com/1533421/142746571-445818b8-9c4d-4e2a-ac7c-4c4f1076667b.png">

<img width="791" alt="スクリーンショット 2021-11-21 11 03 54" src="https://user-images.githubusercontent.com/1533421/142746575-48029c66-c98f-43e9-9c75-1f19f924bfae.png">

