### PR TITLE
ハッシュタグ未指定のときはラベルも消えるようにする

### DIFF
--- a/src/js/preview/preview.js
+++ b/src/js/preview/preview.js
@@ -491,6 +491,7 @@ function csv_array(data) {
   // Hashtag
   try {
     const domEventHashtag = document.querySelector('.js-event-hashtag');
+    const domEventHashtagLabel = document.querySelector('.js-event-hashtag-label');
     const domEventHashtagLink = document.querySelector('.js-event-hashtag-link');
     if (valHashtag != '') {
       domEventHashtagLink.textContent = '#' + valHashtag;
@@ -498,6 +499,7 @@ function csv_array(data) {
       domEventHashtagLink.setAttribute('href', eventHashtagLink);
     } else {
       domEventHashtag.remove();
+      domEventHashtagLabel.remove();
     }
   } catch(error) {
     console.error('Error: Overview hashtag');

--- a/src/templates/pages/preview.ejs
+++ b/src/templates/pages/preview.ejs
@@ -217,9 +217,9 @@ pageId = "preview";
             <dd class="overview-content js-event-title">Event Title</dd>
             <dt class="overview-label">Date</dt>
             <dd class="overview-content js-event-date">2000/01/01 00:00</dd>
-            <dt class="overview-label">Hashtag</dt>
+            <dt class="overview-label js-event-hashtag-label">Hashtag</dt>
             <dd class="overview-content js-event-hashtag">
-              <a href="https://twitter.com/search?q=" class="js-event-hashtag-link">#hashtag</a>
+              <a href="https://twitter.com/hashtag/" class="js-event-hashtag-link">#hashtag</a>
             </dd>
             <dt class="overview-label js-event-venue-label">Venue Label</dt>
             <dd class="overview-content js-event-venue-content">Venue Content</dd>


### PR DESCRIPTION
https://github.com/sanographix/kitekure/pull/15 のhotfix

- ハッシュタグ未指定のときに Overview セクションに「Hashtag」の見出しだけ残っていたが、これも消えるようにした