### PR TITLE
プレビューページがnoindexされるよう、デフォルトの挙動をnoindexに変更

### DIFF
--- a/src/js/preview/preview.js
+++ b/src/js/preview/preview.js
@@ -121,20 +121,6 @@ function csv_array(data) {
     console.error('Error: OGP');
   }
 
-  // 検索避け
-  try {
-    const valRobots = array.filter((value) => value.option === 'Hide on Search Results')[0].value1;
-    // 検索に出す設定ならrobots書き換え
-    if (valRobots == '✅') {
-      const metaRobots = document.createElement('meta');
-      metaRobots.setAttribute('name', 'robots')
-      metaRobots.setAttribute('content', 'noindex');
-      document.head.appendChild(metaRobots);
-    }
-  } catch(error) {
-    console.error('Error: meta-noindex');
-  }
-
   // Date (UTC) (Option)
   // カウントダウンタイマー
   const valDateUtc = array.filter((value) => value.option === 'Date (UTC)')[0].value1;
@@ -616,6 +602,11 @@ function csv_array(data) {
   if (urlParam === "?prebuild=true") {
     // プレビュー用バナーを消す
     document.querySelector('.js-prebuild').remove();
+    // 検索避けない設定の場合noindex消す
+    const valRobots = array.filter((value) => value.option === 'Hide on Search Results')[0].value1;
+    if (valRobots == '-') {
+      document.getElementById('.meta-robots').remove();
+    }
     // jsでの書き換えがロードしきってからDOMを取得する
     window.addEventListener("load", function () {
       let snapshot = new XMLSerializer().serializeToString(document);

--- a/src/js/preview/preview.js
+++ b/src/js/preview/preview.js
@@ -605,7 +605,7 @@ function csv_array(data) {
     // 検索避けない設定の場合noindex消す
     const valRobots = array.filter((value) => value.option === 'Hide on Search Results')[0].value1;
     if (valRobots == '-') {
-      document.getElementById('.meta-robots').remove();
+      document.getElementById('meta-robots').remove();
     }
     // jsでの書き換えがロードしきってからDOMを取得する
     window.addEventListener("load", function () {

--- a/src/templates/_partial/_header.ejs
+++ b/src/templates/_partial/_header.ejs
@@ -9,9 +9,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="theme-color" content="#F70138" id="meta-theme-color" />
     <link rel="stylesheet" href="_src/style.css" />
-    <% if (pageId === 'setup') { %>
-      <meta name="robots" content="noindex" id="meta-robots-for-setup" />
-    <% } %>
+    <meta name="robots" content="noindex" id="meta-robots" />
     <% if (pageId === 'preview') { %>
       <link rel="icon" href="" id="favicon" />
       <link rel="canonical" href="" id="canonical" />


### PR DESCRIPTION
- プレビューページが意図せず noindex されてなかった
- 安全のためデフォルトの挙動を noindex とし、本番用 index.html をダウンロードする直前に noindex を解除するようにした

## 挙動

||検索避ける設定|検索避けない設定|
|-|-|-|
|セットアップ|noindex|noindex|
|プレビュー|noindex|noindex|
|本番|noindex|index|

## キャプチャ (検索避けない設定)

|プレビュー|本番 (noindex消える) |
|-|-|
|<img width="775" alt="スクリーンショット 2021-11-21 17 32 02" src="https://user-images.githubusercontent.com/1533421/142755502-4010d23c-1a27-44c9-bee5-33b382fc1f6f.png">|<img width="730" alt="スクリーンショット 2021-11-21 17 32 20" src="https://user-images.githubusercontent.com/1533421/142755506-4fff2421-3b95-4918-9cc6-f0fcf3f24fba.png">|
